### PR TITLE
macros.hpp gcc compatibility

### DIFF
--- a/include/cereal/macros.hpp
+++ b/include/cereal/macros.hpp
@@ -79,8 +79,14 @@
 #define CEREAL_SAVE_MINIMAL_FUNCTION_NAME save_minimal
 #endif // CEREAL_SAVE_MINIMAL_FUNCTION_NAME
 
-#if !__has_feature(cxx_exceptions) &&!defined(CEREAL_NO_EXCEPTIONS)
-#  define CEREAL_NO_EXCEPTIONS
+#if defined(__clang__) // By Juneyoung Lee; __has_feature is available only in clang compiler
+#  if !__has_feature(cxx_exceptions) &&!defined(CEREAL_NO_EXCEPTIONS)
+#    define CEREAL_NO_EXCEPTIONS
+#  endif
+#elif defined(__GNUC__) || defined(__GNUG__) // By Juneyoung Lee
+#  if !defined(__EXCEPTIONS) && !defined(CEREAL_NO_EXCEPTIONS)
+#    define CEREAL_NO_EXCEPTIONS
+#  endif
 #endif
 
 #endif // CEREAL_MACROS_HPP_

--- a/include/cereal/macros.hpp
+++ b/include/cereal/macros.hpp
@@ -79,11 +79,11 @@
 #define CEREAL_SAVE_MINIMAL_FUNCTION_NAME save_minimal
 #endif // CEREAL_SAVE_MINIMAL_FUNCTION_NAME
 
-#if defined(__clang__) // By Juneyoung Lee; __has_feature is available only in clang compiler
+#if defined(__clang__)
 #  if !__has_feature(cxx_exceptions) &&!defined(CEREAL_NO_EXCEPTIONS)
 #    define CEREAL_NO_EXCEPTIONS
 #  endif
-#elif defined(__GNUC__) || defined(__GNUG__) // By Juneyoung Lee
+#elif defined(__GNUC__) || defined(__GNUG__)
 #  if !defined(__EXCEPTIONS) && !defined(CEREAL_NO_EXCEPTIONS)
 #    define CEREAL_NO_EXCEPTIONS
 #  endif


### PR DESCRIPTION
강지훈 선배님께

gcc를 이용해서 컴파일 할 때에 뜨던 exception관련 컴파일 에러를 제거하기 위해 수정한 macros.hpp를 보내드립니다.
